### PR TITLE
Fix: Adjust application height to be content-driven

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
   }, [prompt]);
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center justify-center py-8 px-4 selection:bg-indigo-500 selection:text-white">
+    <div className="bg-gray-900 text-gray-100 flex flex-col items-center justify-center py-12 px-4 selection:bg-indigo-500 selection:text-white">
       <div className="w-full max-w-2xl space-y-8">
         <header className="text-center">
           <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl">

--- a/index.html
+++ b/index.html
@@ -30,8 +30,7 @@
       }
       /* Ensure root and its direct child fill height for flex layouts */
       html, body, #root, #root > div {
-        min-height: 100vh;
-        height: 100%; /* Added for better consistency with min-height */
+        /* min-height and height properties removed */
       }
     </style>
 <script type="importmap">


### PR DESCRIPTION
Removed full-screen height enforcement from index.html and App.tsx.

- In index.html, removed `min-height: 100vh` and `height: 100%` from `html, body, #root, #root > div`.
- In App.tsx, removed `min-h-screen` from the main container and adjusted vertical padding from `py-8` to `py-12`.

These changes ensure the application's height wraps its content rather than always filling the viewport, addressing the issue of the application being too tall.